### PR TITLE
Added option for writing output files

### DIFF
--- a/optlnls/hybrid.py
+++ b/optlnls/hybrid.py
@@ -182,7 +182,7 @@ def run_hybrid(beam, units=2, diff_plane=1, calcType=2, dist_to_img_calc=0, dist
                 input_parameters.ghy_automatic = automatic
             
                 try:
-                    calculation_parameters = hy_run(input_parameters)
+                    calculation_parameters = hy_run(input_parameters,write_file)
                     
                     distance = input_parameters.ghy_distance
                     nbins_x = int(input_parameters.ghy_nbins_x)


### PR DESCRIPTION
Simulações com HYBRID sempre criavam arquivos do tipo mirr.0n, star.0n, screen.0n, optax.0n (...) usadas apenas enquanto o código roda. Esses arquivos são grandes (unidades de GB) e são gerados para cada elemento óptico sendo simulado. Adicionei um argumento extra nas funções do HYBRID para manter esses arquivos ou não. Os arquivos ainda são gerados, mas agora são deletados do sistema assim que se tornam desnecessários.