### PR TITLE
feat(source): add verbose flag to srw_undulator_spectrum and propagate to shadow.calc_und_flux

### DIFF
--- a/optlnls/shadow.py
+++ b/optlnls/shadow.py
@@ -74,7 +74,7 @@ def calc_und_flux(beam, nbins, eBeamEnergy, eSpread, current,
     precision = [min_harmonic, max_harmonic, 1.0, 1.0]   
     
     
-    und_spec = srw_undulator_spectrum(mag_field, electron_beam, energy_grid, sampling_mesh, precision)   
+    und_spec = srw_undulator_spectrum(mag_field, electron_beam, energy_grid, sampling_mesh, precision, verbose = verbose)   
     BL_spec = und_spec*T_E
     
     if(show_plots):

--- a/optlnls/source.py
+++ b/optlnls/source.py
@@ -87,7 +87,8 @@ def und_source(emittance, beta, e_spread, und_length, und_period, ph_energy, har
     return sph_h, sphp_h
 
 
-def srw_undulator_spectrum(mag_field=[], electron_beam=[], energy_grid=[], sampling_mesh=[], precision=[]):
+def srw_undulator_spectrum(mag_field=[], electron_beam=[], energy_grid=[], sampling_mesh=[], precision=[],
+                           verbose: bool = True):
     """
     Calls SRW to calculate spectrum for a planar or elliptical undulator\n
     :mag_field: list containing: [period [m], length [m], Bx [T], By [T], phase Bx = 0, phase By = 0, Symmetry Bx = +1, Symmetry By = -1]
@@ -148,9 +149,10 @@ def srw_undulator_spectrum(mag_field=[], electron_beam=[], energy_grid=[], sampl
            
     
     #**********************Calculation (SRWLIB function calls)
-    print('   Performing Spectral Flux (Stokes parameters) calculation ... ')
+    if verbose:
+        print('   Performing Spectral Flux (Stokes parameters) calculation ... ')
     CalcStokesUR(stkF, eBeam, und, arPrecF)
-    print('done')
+    if verbose: print('done')
     
     return nparray(stkF.arS[0:energy_grid[2]])
 


### PR DESCRIPTION
# Summary

This PR introduces a `verbose` parameter to the `srw_undulator_spectrum` function in `source.py` and propagates it to `calc_und_flux` in `shadow.py`. The goal is to allow optional suppression of print statements during flux calculation.

# Changes
- Added `verbose: bool = True` parameter to `srw_undulator_spectrum`.
- Updated print statements to respect the `verbose` flag.
- Modified `calc_und_flux` in `shadow.py` to pass the `verbose` argument.

# Why
Currently, the function always prints messages during execution, which can clutter logs in automated workflows. This change provides better control over output verbosity.

# Impact
- No breaking changes: default behavior remains verbose.