### PR TITLE
fix(numpy): replace deprecated np.float with builtin float

### DIFF
--- a/optlnls/mirror.py
+++ b/optlnls/mirror.py
@@ -114,7 +114,7 @@ def read_RefractiveIndexInfo(filename, wl_range=[0,0]):
         for line in lines:
             line = line.split(',')
             try:
-                line = np.array(line, dtype=np.float)
+                line = np.array(line, dtype=float)
                 if(j==1): 
                     n.append(line.tolist())
                 else:

--- a/optlnls/shadow.py
+++ b/optlnls/shadow.py
@@ -278,7 +278,7 @@ def append_dataset_hdf5(filename, data, z, nz, tag, t0, ndigits):
     
     with h5py.File(filename, 'a') as f:
         dset = f['datasets'].create_dataset('step_{0:0{ndigits}d}'.format(tag, ndigits=ndigits),
-                                            data=np.array(data['histogram'], dtype=np.float), 
+                                            data=np.array(data['histogram'], dtype=float), 
                                             compression="gzip")
         dset.attrs['z'] = z 
         dset.attrs['xStart'] = data['bin_h_center'].min()
@@ -436,8 +436,8 @@ def read_caustic(filename, write_attributes=False, plot=False, plot2D=False,
             for key in list(outdict.keys()):
                 f.attrs[key] = outdict[key]
                 
-            f.create_dataset('histoXZ', data=histoH, dtype=np.float, compression="gzip")
-            f.create_dataset('histoYZ', data=histoV, dtype=np.float, compression="gzip")
+            f.create_dataset('histoXZ', data=histoH, dtype=float, compression="gzip")
+            f.create_dataset('histoYZ', data=histoV, dtype=float, compression="gzip")
             
     if(print_minimum):
         print('\n   ****** \n' + '   Z min (rms-hor): {0:.3e}'.format(rms_min_z[0]))


### PR DESCRIPTION
NumPy >= 1.24 removed deprecated aliases such as np.float. 
Since the project does not pin a NumPy version, installations may resolve to 1.24+, which raises an AttributeError at runtime.

This change replaces np.float with the builtin float. 
Because np.float was only an alias for float, no behavioral or numerical changes are expected.

This restores compatibility with NumPy >= 1.24.